### PR TITLE
Updates for Rack v2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "WrongPeople",
   "name": "Wrong People",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "license": "GPL-3.0",
   "brand": "Wrong People",
   "author": "Wrong People",

--- a/src/LuaModule.cpp
+++ b/src/LuaModule.cpp
@@ -52,7 +52,7 @@ void Lua::loadScript() {
         }
         else {
             scriptLoaded = true;
-            displayMessage = string::filename(scriptPath);
+            displayMessage = rack::system::getFilename(scriptPath);
             lights[RELOAD_LIGHT_GREEN].setBrightness(1);
             lights[RELOAD_LIGHT_RED].setBrightness(0);
         }
@@ -185,7 +185,7 @@ bool Lua::createLuaState() {
     lua_getglobal(L, "package");
     lua_getfield(L, -1, "path");
     std::string path = lua_tostring(L, -1);
-    path.append(";" + rack::string::directory(scriptPath) + DIR_SEP + "?.lua");
+    path.append(";" + rack::system::getDirectory(scriptPath) + DIR_SEP + "?.lua");
     lua_pop(L, 1);
     lua_pushstring(L, path.c_str());
     lua_setfield(L, -2, "path");
@@ -277,7 +277,7 @@ struct LoadScriptItem : MenuItem {
     Lua *module;
 
     void onAction(const event::Action &e) override {
-        std::string dir = module->scriptPath.empty() ? "" : rack::string::directory(module->scriptPath).c_str();
+        std::string dir = module->scriptPath.empty() ? "" : rack::system::getDirectory(module->scriptPath).c_str();
         osdialog_filters *filters = osdialog_filters_parse("Lua Script:lua,luna,lunaire,anair");
         char *path = osdialog_file(OSDIALOG_OPEN, dir.empty() ? "" : dir.c_str(), NULL, filters);
         if(path) {

--- a/src/LuaModule.hpp
+++ b/src/LuaModule.hpp
@@ -103,6 +103,11 @@ struct Lua : Module {
     Lua() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(RELOAD_PARAM, 0.0, 1.0, 0.0, "Reload Script");
+
+        for (int i = 0; i < SCRIPT_PORTS; i++) {
+            configInput(SCRIPT_INPUTS + i, string::f("Input %d", i));
+            configOutput(SCRIPT_OUTPUTS + i, string::f("Output %d", i));
+        }
         onReset();
     }
 

--- a/src/LuaModule.hpp
+++ b/src/LuaModule.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include "plugin.hpp"
 #include "osdialog.h"
 

--- a/src/MIDIPlayer.cpp
+++ b/src/MIDIPlayer.cpp
@@ -57,7 +57,7 @@ void MIDIPlayer::loadFile() {
         midiFile.doTimeAnalysis();
         midiFile.linkNotePairs();
         midiFile.joinTracks();
-        fileName = string::filename(filePath);
+        fileName = rack::system::getFilename(filePath);
         fileDuration = (float) midiFile.getFileDurationInSeconds();
         fileDurationStr = timeToString(fileDuration);
         fileLoaded = true;
@@ -322,7 +322,7 @@ struct LoadFileItem : MenuItem {
     MIDIPlayer *module;
 
     void onAction(const event::Action &e) override {
-        std::string dir = module->filePath.empty() ? "" : rack::string::directory(module->filePath).c_str();
+        std::string dir = module->filePath.empty() ? "" : rack::system::getDirectory(module->filePath).c_str();
         osdialog_filters *filters = osdialog_filters_parse("MIDI File:mid,midi");
         char *path = osdialog_file(OSDIALOG_OPEN, dir.empty() ? "" : dir.c_str(), NULL, filters);
         if(path) {

--- a/src/MIDIPlayer.hpp
+++ b/src/MIDIPlayer.hpp
@@ -115,8 +115,17 @@ struct MIDIPlayer : Module {
         configParam(STOP_PARAM, 0.0, 1.0, 0.0, "Stop");
         configParam(LOOP_PARAM, 0.0, 1.0, 0.0, "Loop");
 
+        configInput(PLAY_INPUT, "Play trigger");
+        configInput(STOP_INPUT, "Stop trigger");
+        configOutput(PLAY_OUTPUT, "Play trigger");
+        configOutput(STOP_OUTPUT, "Stop trigger");
+
         for(int t = 0; t < TRACKS; t++) {
             heldNotes[t].reserve(128);
+            configOutput(CV_OUTPUTS + t, string::f("Track %d v/oct pitch", t + 1));
+            configOutput(GATE_OUTPUTS + t, string::f("Track %d gate", t + 1));
+            configOutput(VELOCITY_OUTPUTS + t, string::f("Track %d velocity", t + 1));
+            configOutput(RETRIGGER_OUTPUTS + t, string::f("Track %d retrigger", t + 1));
         }
         onReset();
     }

--- a/src/Tourette.hpp
+++ b/src/Tourette.hpp
@@ -211,7 +211,16 @@ struct Tourette : Module {
         configParam(Tourette::ATTACK_PARAM, 0.0, 1.0, 0.0, "Attack", " s");
         configParam(Tourette::RELEASE_PARAM, 0.0, 1.0, 0.0, "Release", " s");
         configParam(Tourette::POLY_PARAM, 1.0, 8.0, 4.0, "Max polyphony");
-        configParam(Tourette::STEREO_PARAM, 0.f, 1.f, 0.f, "Stereo mode");
+        configSwitch(Tourette::STEREO_PARAM, 0.f, 1.f, 0.f, "Stereo mode", {"Split", "Stereo"});
+
+        configInput(SIG_A_INPUT, "Signal A");
+        configInput(SIG_B_INPUT, "Signal B");
+        configInput(PLAY_INPUT, "Trigger");
+        configOutput(SIG_A_OUTPUT, "Signal A");
+        configOutput(SIG_B_OUTPUT, "Signal B");
+
+        configBypass(SIG_A_INPUT, SIG_A_OUTPUT);
+        configBypass(SIG_B_INPUT, SIG_B_OUTPUT);
 
         onSampleRateChange();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,7 +3,7 @@
 
 void systemCreateDirectory(std::string path) {
 #if ARCH_WIN
-    CreateDirectory(path.c_str(), NULL);
+    CreateDirectoryA(path.c_str(), NULL);
 #else
     mkdir(path.c_str(), 0755);
 #endif


### PR DESCRIPTION
Hi there. Your modules are pretty great, so I thought I would make the update for it to work with Rack v2

The only thing I had to do to make it compatible with the Rack 2 API is to change instances of `rack::string::filename` to `rack::system::getFilename` and instances of `rack::string::directory` to `rack::system::getDirectory`.

Here is a summary of changes:
- Correct instances of `rack::string::filename` and `rack::string::directory`
- Add a missing `#include <iostream>` (it complained for me, not sure if you have different settings in environment)
- Add labels for inputs and outputs (part of the new Rack API, you can see the labels when you hover or right click them in VCV).
- Add bypass for Tourette as well (part of new Rack API can specify straight pass through signals when a module is bypassed).