### PR TITLE
Add menu option on Tourette module to clear buffers

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "WrongPeople",
   "name": "Wrong People",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "license": "GPL-3.0",
   "brand": "Wrong People",
   "author": "Wrong People",

--- a/src/LuaModule.cpp
+++ b/src/LuaModule.cpp
@@ -52,7 +52,7 @@ void Lua::loadScript() {
         }
         else {
             scriptLoaded = true;
-            displayMessage = string::filename(scriptPath);
+            displayMessage = rack::system::getFilename(scriptPath);
             lights[RELOAD_LIGHT_GREEN].setBrightness(1);
             lights[RELOAD_LIGHT_RED].setBrightness(0);
         }
@@ -185,7 +185,7 @@ bool Lua::createLuaState() {
     lua_getglobal(L, "package");
     lua_getfield(L, -1, "path");
     std::string path = lua_tostring(L, -1);
-    path.append(";" + rack::string::directory(scriptPath) + DIR_SEP + "?.lua");
+    path.append(";" + rack::system::getDirectory(scriptPath) + DIR_SEP + "?.lua");
     lua_pop(L, 1);
     lua_pushstring(L, path.c_str());
     lua_setfield(L, -2, "path");
@@ -277,7 +277,7 @@ struct LoadScriptItem : MenuItem {
     Lua *module;
 
     void onAction(const event::Action &e) override {
-        std::string dir = module->scriptPath.empty() ? "" : rack::string::directory(module->scriptPath).c_str();
+        std::string dir = module->scriptPath.empty() ? "" : rack::system::getDirectory(module->scriptPath).c_str();
         osdialog_filters *filters = osdialog_filters_parse("Lua Script:lua,luna,lunaire,anair");
         char *path = osdialog_file(OSDIALOG_OPEN, dir.empty() ? "" : dir.c_str(), NULL, filters);
         if(path) {

--- a/src/LuaModule.hpp
+++ b/src/LuaModule.hpp
@@ -103,6 +103,11 @@ struct Lua : Module {
     Lua() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(RELOAD_PARAM, 0.0, 1.0, 0.0, "Reload Script");
+
+        for (int i = 0; i < SCRIPT_PORTS; i++) {
+            configInput(SCRIPT_INPUTS + i, string::f("Input %d", i));
+            configOutput(SCRIPT_OUTPUTS + i, string::f("Output %d", i));
+        }
         onReset();
     }
 

--- a/src/LuaModule.hpp
+++ b/src/LuaModule.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include "plugin.hpp"
 #include "osdialog.h"
 

--- a/src/MIDIPlayer.cpp
+++ b/src/MIDIPlayer.cpp
@@ -57,7 +57,7 @@ void MIDIPlayer::loadFile() {
         midiFile.doTimeAnalysis();
         midiFile.linkNotePairs();
         midiFile.joinTracks();
-        fileName = string::filename(filePath);
+        fileName = rack::system::getFilename(filePath);
         fileDuration = (float) midiFile.getFileDurationInSeconds();
         fileDurationStr = timeToString(fileDuration);
         fileLoaded = true;
@@ -322,7 +322,7 @@ struct LoadFileItem : MenuItem {
     MIDIPlayer *module;
 
     void onAction(const event::Action &e) override {
-        std::string dir = module->filePath.empty() ? "" : rack::string::directory(module->filePath).c_str();
+        std::string dir = module->filePath.empty() ? "" : rack::system::getDirectory(module->filePath).c_str();
         osdialog_filters *filters = osdialog_filters_parse("MIDI File:mid,midi");
         char *path = osdialog_file(OSDIALOG_OPEN, dir.empty() ? "" : dir.c_str(), NULL, filters);
         if(path) {

--- a/src/MIDIPlayer.hpp
+++ b/src/MIDIPlayer.hpp
@@ -115,8 +115,17 @@ struct MIDIPlayer : Module {
         configParam(STOP_PARAM, 0.0, 1.0, 0.0, "Stop");
         configParam(LOOP_PARAM, 0.0, 1.0, 0.0, "Loop");
 
+        configInput(PLAY_INPUT, "Play trigger");
+        configInput(STOP_INPUT, "Stop trigger");
+        configOutput(PLAY_OUTPUT, "Play trigger");
+        configOutput(STOP_OUTPUT, "Stop trigger");
+
         for(int t = 0; t < TRACKS; t++) {
             heldNotes[t].reserve(128);
+            configOutput(CV_OUTPUTS + t, string::f("Track %d v/oct pitch", t + 1));
+            configOutput(GATE_OUTPUTS + t, string::f("Track %d gate", t + 1));
+            configOutput(VELOCITY_OUTPUTS + t, string::f("Track %d velocity", t + 1));
+            configOutput(RETRIGGER_OUTPUTS + t, string::f("Track %d retrigger", t + 1));
         }
         onReset();
     }

--- a/src/Tourette.hpp
+++ b/src/Tourette.hpp
@@ -205,7 +205,7 @@ struct Tourette : Module {
         configParam(THRESH_LO_PARAM, -60.f, 3.f, -42.f, "Low Threshold", " dB");
         configParam(THRESH_HI_PARAM, -54.f, 6.f, -18.f, "High Threshold", " dB");
         configParam(Tourette::MIN_LEN_PARAM, -0.3f, 0.3, -0.1f, "Min shot length", " s");
-        configParam(Tourette::MAX_LEN_PARAM, -1.0f, 1.0, -0.3f, "Max shot length", " s");
+        configParam(Tourette::MAX_LEN_PARAM, -1.0f, 3.0, -0.3f, "Max shot length", " s");
         configParam(Tourette::REPEATS_PARAM, 1.0, 16.0, 8.0, "Repeats");
         configParam(Tourette::RAND_PARAM, 0.0, 1.0, 0.5, "Randomness");
         configParam(Tourette::ATTACK_PARAM, 0.0, 1.0, 0.0, "Attack", " s");

--- a/src/Tourette.hpp
+++ b/src/Tourette.hpp
@@ -200,7 +200,7 @@ struct Tourette : Module {
     unsigned int maxBufSize = 0;
 
     Tourette() {
-		config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+        config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
         configParam(THRESH_LO_PARAM, -60.f, 3.f, -42.f, "Low Threshold", " dB");
         configParam(THRESH_HI_PARAM, -54.f, 6.f, -18.f, "High Threshold", " dB");
@@ -233,6 +233,7 @@ struct Tourette : Module {
         }
     }
 
+    void onReset() override;
     void onSampleRateChange() override;
 
     void process(const ProcessArgs &args) override;
@@ -246,5 +247,6 @@ struct Tourette : Module {
     void processInputsSplit();
     void processInputsStereo();
     void processBuffers();
+    void clearBuffers();
 
 };

--- a/src/Tourette.hpp
+++ b/src/Tourette.hpp
@@ -209,7 +209,7 @@ struct Tourette : Module {
         configParam(Tourette::REPEATS_PARAM, 1.0, 16.0, 8.0, "Repeats");
         configParam(Tourette::RAND_PARAM, 0.0, 1.0, 0.5, "Randomness");
         configParam(Tourette::ATTACK_PARAM, 0.0, 1.0, 0.0, "Attack", " s");
-        configParam(Tourette::RELEASE_PARAM, 0.0, 1.0, 0.0, "Release", " s");
+        configParam(Tourette::RELEASE_PARAM, 0.0, 3.0, 0.0, "Release", " s");
         configParam(Tourette::POLY_PARAM, 1.0, 8.0, 4.0, "Max polyphony");
         configSwitch(Tourette::STEREO_PARAM, 0.f, 1.f, 0.f, "Stereo mode", {"Split", "Stereo"});
 

--- a/src/Tourette.hpp
+++ b/src/Tourette.hpp
@@ -211,7 +211,16 @@ struct Tourette : Module {
         configParam(Tourette::ATTACK_PARAM, 0.0, 1.0, 0.0, "Attack", " s");
         configParam(Tourette::RELEASE_PARAM, 0.0, 1.0, 0.0, "Release", " s");
         configParam(Tourette::POLY_PARAM, 1.0, 8.0, 4.0, "Max polyphony");
-        configParam(Tourette::STEREO_PARAM, 0.f, 1.f, 0.f, "Stereo mode");
+        configSwitch(Tourette::STEREO_PARAM, 0.f, 1.f, 0.f, "Stereo mode", {"Split", "Stereo"});
+
+        configInput(SIG_A_INPUT, "Signal A");
+        configInput(SIG_B_INPUT, "Signal B");
+        configInput(PLAY_INPUT, "Trigger");
+        configOutput(SIG_A_OUTPUT, "Signal A");
+        configOutput(SIG_B_OUTPUT, "Signal B");
+
+        configBypass(SIG_A_INPUT, SIG_A_OUTPUT);
+        configBypass(SIG_B_INPUT, SIG_B_OUTPUT);
 
         onSampleRateChange();
 


### PR DESCRIPTION
This is a solution for Issue #6. It adds a menu option to the Tourette module to "Clear buffers." When selected it will turn off all the current sample buffers and allow for new buffers to be recorded. I think having a CV input to perform this function would be better, but there is no room on the module panel.